### PR TITLE
update font-awesome and fix icon names

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="shortcut icon" href="favicon.ico" />
   <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <link href="{{site.baseurl}}/css/style.css" rel="stylesheet" />
   <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
@@ -46,8 +46,8 @@
           <li><a href="https://github.com/code4hr" title="GitHub"><i class="fa fa-github fa-lg"></i></a></li>
           <li><a href="https://facebook.com/code4hr" title="Facebook"><i class="fa fa-facebook fa-lg"></i></a></li>
           <li><a href="https://twitter.com/code4hr" title="Twitter"><i class="fa fa-twitter fa-lg"></i></a></li>
-          <li><a href="http://codeforva-slack.herokuapp.com/" title="Slack Chat"><i class="fa fa-comments fa-lg"></i></a></li>
-          <li><a href="http://meetup.com/code4hr" title="Meetup"><i class="fa fa-users fa-lg"></i></a></li>
+          <li><a href="http://codeforva-slack.herokuapp.com/" title="Slack Chat"><i class="fa fa-slack fa-lg"></i></a></li>
+          <li><a href="http://meetup.com/code4hr" title="Meetup"><i class="fa fa-meetup fa-lg"></i></a></li>
           <li><a href="http://codeforamerica.tumblr.com" title="Tumblr"><i class="fa fa-tumblr fa-lg"></i></a></li>
         </ul>
       </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
Updated font-awesome version from 4.2.0 to 4.7.0 and renamed icons for Slack and Meetup to "fa-slack" and "fa-meetup".